### PR TITLE
Add tip with fix for Kubernetes HTTP 403 error

### DIFF
--- a/docs/docker/installation.md
+++ b/docs/docker/installation.md
@@ -44,11 +44,9 @@ Then deploy it to Kubernetes with this command:
 
     This problem should manifest itself as an HTTP 403 error when running plugins. To give your default
     service account the necessary "view" permissions, run the following:
+
     ```
-    kubectl create rolebinding default-view \
-      --clusterrole=view \
-      --serviceaccount=default:default \
-      --namespace=default
+    kubectl create rolebinding default-view --clusterrole=view --serviceaccount=default:default --namespace=default
     ```
 
 - - -

--- a/docs/docker/installation.md
+++ b/docs/docker/installation.md
@@ -38,12 +38,12 @@ Then deploy it to Kubernetes with this command:
     If you used kubeadm to setup your cluster, or if you use [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/), 
     the default service account will not have some permissions. We use your cluster's configuration to talk to
     the API, which uses [service accounts](https://kubernetes.io/docs/admin/service-accounts-admin/).
-    kubeadm sets up [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/),
+    Kubeadm sets up [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/),
     which in turn by default grants [no permissions](https://kubernetes.io/docs/admin/authorization/rbac/#service-account-permissions)
     outside of the "kube-system" namespace.
 
-    This problem should manifest itself as an HTTP 403 error when running plugins. To give your default
-    service account the necessary "view" permissions, run the following:
+    This problem will manifest itself as an HTTP 403 error when running plugins.  
+    To give your default service account the necessary "view" permissions, run the following:
 
     ```
     kubectl create rolebinding default-view --clusterrole=view --serviceaccount=default:default --namespace=default

--- a/docs/docker/installation.md
+++ b/docs/docker/installation.md
@@ -34,6 +34,23 @@ Then deploy it to Kubernetes with this command:
 
     kubectl apply -f kubernetes_daemonset.yaml
 
+!!! Tip
+    If you used kubeadm to setup your cluster, or if you use [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/), 
+    the default service account will not have some permissions. We use your cluster's configuration to talk to
+    the API, which uses [service accounts](https://kubernetes.io/docs/admin/service-accounts-admin/).
+    kubeadm sets up [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/),
+    which in turn by default grants [no permissions](https://kubernetes.io/docs/admin/authorization/rbac/#service-account-permissions)
+    outside of the "kube-system" namespace.
+
+    This problem should manifest itself as an HTTP 403 error when running plugins. To give your default
+    service account the necessary "view" permissions, run the following:
+    ```
+    kubectl create rolebinding default-view \
+      --clusterrole=view \
+      --serviceaccount=default:default \
+      --namespace=default
+    ```
+
 - - -
 
 ### Deploying on Swarm


### PR DESCRIPTION
As the tip reads, when using RBAC the defaul service account does not
have necessary permissions. The tip includes a fix.